### PR TITLE
add functionality to use .env file for bot token and other env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+BOT_TOKEN = '<insert_token_here>'
+ENV = 'develop'
+DB_USER = 'root'
+DB_PASS = ''
+DB_NAME = 'event_bot'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 memory
 src
+.env

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Once this is done, the database can be setup with:
 python3 bin/setup_db.py
 ```
 
-Before the app can be run, you'll need to set the `BOT_TOKEN` env variable with the
-token of your Discord bot.
+Before the app can be run, you'll need to create an `.env` file. Please look at the `.env.example` file and set the `BOT_TOKEN` env variable with the token of your Discord bot.
+
 
 The app can then be run with:
 ```

--- a/app.py
+++ b/app.py
@@ -1,10 +1,17 @@
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from event_bot import *
 from event_bot.commands import * 
 from event_bot.events import *
+
+# Load .env file
+env_path = Path('.') / '.env'
+load_dotenv(dotenv_path=env_path)
 
 env = os.getenv('ENV', 'develop')
 db_user = os.getenv('DB_USER', 'root')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dotenv==0.8.2
 SQLAlchemy==1.2.8
 mysqlclient==1.3.12
 yarl<1.2


### PR DESCRIPTION
Added functionality to use .env file for bot token. One thing to consider if whether we want `override=True` on the env files, if its true it will override current os environment settings, thoughts? @jgayfer 