### PR TITLE
Display events in event channel

### DIFF
--- a/event_bot/commands/event_command.py
+++ b/event_bot/commands/event_command.py
@@ -2,7 +2,7 @@ from discord.ext import commands
 from sqlalchemy.orm import joinedload
 
 from event_bot.models import Event, EventChannel, Guild
-from event_bot.queries import find_or_create_guild
+from event_bot.queries import find_or_create_guild, find_or_create_user
 
 
 class EventCommand:
@@ -75,6 +75,7 @@ class EventCommand:
     async def _get_event_from_user(self, ctx):
         """Create an event with user input via private messages"""
         event = Event()
+        event.organizer = find_or_create_user(self.bot.transaction, ctx.author.id)
         event.title = await self._get_title_from_user(ctx)
         event.description = await self._get_desc_from_user(ctx)
         event.capacity = await self._get_capacity_from_user(ctx)

--- a/event_bot/commands/event_command.py
+++ b/event_bot/commands/event_command.py
@@ -23,6 +23,7 @@ class EventCommand:
         with self.bot.transaction.new() as session:
             session.add(event)
         await ctx.author.send("Your event has been created!")
+        await self.bot.list_events(event.event_channel)
 
 
     async def _get_capacity_from_user(self, ctx):

--- a/event_bot/commands/event_command.py
+++ b/event_bot/commands/event_command.py
@@ -54,7 +54,7 @@ class EventCommand:
     async def _get_event_channel(self, ctx):
         """Find or create the event channel for the current guild"""
         guild = find_or_create_guild(self.bot.transaction, ctx.guild.id, joinedload('event_channels'))
-        if guild.has_multiple_event_channels():
+        if guild.has_single_event_channel():
             return guild.event_channels[0]
         else:
             channel = await self.bot.create_discord_event_channel(ctx.guild)

--- a/event_bot/embeds/__init__.py
+++ b/event_bot/embeds/__init__.py
@@ -1,0 +1,1 @@
+from .event_embed import event_embed

--- a/event_bot/embeds/event_embed.py
+++ b/event_bot/embeds/event_embed.py
@@ -1,0 +1,11 @@
+import discord
+
+
+SKULL_EMOJI = '\U0001f480'
+
+def event_embed(event, organizer_name):
+    embed = discord.Embed()
+    embed.title = event.title
+    if event.description : embed.description = event.description
+    embed.set_footer(text=f"Created by {organizer_name} | React with {SKULL_EMOJI} to remove this event")
+    return embed

--- a/event_bot/event_bot.py
+++ b/event_bot/event_bot.py
@@ -1,6 +1,8 @@
 import discord
 from discord.ext import commands
 
+from .embeds import event_embed
+
 
 class EventBot(commands.AutoShardedBot):
 
@@ -28,3 +30,17 @@ class EventBot(commands.AutoShardedBot):
                 guild.me: discord.PermissionOverwrite(send_messages=True, add_reactions=True)
                 }
         return await guild.create_text_channel("events", overwrites=overwrites)
+
+
+    async def list_events(self, event_channel):
+        """Clear the given event channel and then populate it with events"""
+        channel = self.get_channel(event_channel.id)
+        await channel.purge()
+        for event in event_channel.events:
+            organizer = self.find_guild_member(event_channel.guild_id, event.organizer_id)
+            await channel.send(embed=event_embed(event, organizer.display_name))
+
+
+    def find_guild_member(self, guild_id, user_id):
+        """Retrieve a member with given id that belongs to the given guild"""
+        return self.get_guild(guild_id).get_member(user_id)

--- a/event_bot/models/event.py
+++ b/event_bot/models/event.py
@@ -8,7 +8,7 @@ class Event(Base):
     __tablename__ = 'event'
     id = Column(Integer, primary_key=True)
     event_channel_id = Column(BigInteger, ForeignKey('event_channel.id', ondelete='CASCADE'))
-    user_id = Column(BigInteger, ForeignKey('user.id', ondelete='CASCADE'))
+    organizer_id = Column(BigInteger, ForeignKey('user.id', ondelete='CASCADE'))
     message_id = Column(BigInteger)
     title = Column(Text)
     description = Column(Text)


### PR DESCRIPTION
This PR adds basic functionality for displaying events. When an event is created, we can refresh the corresponding event channel to display the newly created event.

I decided to put the functionality for displaying events on `event_bot.py`, as we will need to use this same functionality when an event is deleted.

This PR does not add any functionality for interacting with events (such as reacting with the skull emoji); these will come later on.

**Note:** This PR changes the DB schema. The DB will need to be reset.

#### Example
![screenshot from 2018-06-23 12-01-59](https://user-images.githubusercontent.com/10660608/41812746-48a6b82e-76dd-11e8-839f-8e8137ea412c.png)
