### PR TITLE
Comment out unused environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 BOT_TOKEN = '<insert_token_here>'
-ENV = ''
-DB_USER = ''
-DB_PASS = ''
-DB_NAME = ''
+
+# Uncomment the env variables you wish to modify
+# ENV =
+# DB_USER =
+# DB_PASS =
+# DB_NAME =


### PR DESCRIPTION
These environment variables were getting set to an empty string, which
was overriding the defaults. I've commented them out so that they are no
longer applied.