### PR TITLE
Persist the current message id for each Event

### DIFF
--- a/event_bot/commands/event_command.py
+++ b/event_bot/commands/event_command.py
@@ -1,6 +1,7 @@
 from discord.ext import commands
 from sqlalchemy.orm import joinedload
 
+from event_bot.list_events import list_events
 from event_bot.models import Event, EventChannel, Guild
 from event_bot.queries import find_or_create_guild, find_or_create_user
 
@@ -23,7 +24,7 @@ class EventCommand:
         with self.bot.transaction.new() as session:
             session.add(event)
         await ctx.author.send("Your event has been created!")
-        await self.bot.list_events(event.event_channel)
+        await list_events(self.bot, event.event_channel)
 
 
     async def _get_capacity_from_user(self, ctx):

--- a/event_bot/event_bot.py
+++ b/event_bot/event_bot.py
@@ -1,8 +1,6 @@
 import discord
 from discord.ext import commands
 
-from .embeds import event_embed
-
 
 class EventBot(commands.AutoShardedBot):
 
@@ -30,15 +28,6 @@ class EventBot(commands.AutoShardedBot):
                 guild.me: discord.PermissionOverwrite(send_messages=True, add_reactions=True)
                 }
         return await guild.create_text_channel("events", overwrites=overwrites)
-
-
-    async def list_events(self, event_channel):
-        """Clear the given event channel and then populate it with events"""
-        channel = self.get_channel(event_channel.id)
-        await channel.purge()
-        for event in event_channel.events:
-            organizer = self.find_guild_member(event_channel.guild_id, event.organizer_id)
-            await channel.send(embed=event_embed(event, organizer.display_name))
 
 
     def find_guild_member(self, guild_id, user_id):

--- a/event_bot/list_events.py
+++ b/event_bot/list_events.py
@@ -1,0 +1,10 @@
+from .embeds import event_embed
+
+
+async def list_events(bot, event_channel):
+    """Clear the given event channel and then populate it with its events"""
+    channel = bot.get_channel(event_channel.id)
+    await channel.purge()
+    for event in event_channel.events:
+        organizer = bot.find_guild_member(event_channel.guild_id, event.organizer_id)
+        await channel.send(embed=event_embed(event, organizer.display_name))

--- a/event_bot/list_events.py
+++ b/event_bot/list_events.py
@@ -5,6 +5,11 @@ async def list_events(bot, event_channel):
     """Clear the given event channel and then populate it with its events"""
     channel = bot.get_channel(event_channel.id)
     await channel.purge()
+
     for event in event_channel.events:
         organizer = bot.find_guild_member(event_channel.guild_id, event.organizer_id)
-        await channel.send(embed=event_embed(event, organizer.display_name))
+        event_msg = await channel.send(embed=event_embed(event, organizer.display_name))
+        event.message_id = event_msg.id
+
+    with bot.transaction.new() as session:
+        session.add(event_channel)


### PR DESCRIPTION
When a user adds a reaction to an event message, we need to be able to determine what event they are attempting to interact with. By attaching a message id to each event, we can easily look up the corresponding event in the database.

It's worth noting that updating the `message_id` attribute on all the events in a server is done in a single query (I initially had a loop that resulted in the number of queries being equal to the number of events that exist in a server - woops).

I also did a little refactoring here to help keep things looking tidy!